### PR TITLE
Fix converting epics

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -1470,7 +1470,7 @@ class Adventure(BaseCog):
                         box(
                             _(
                                 "Successfully converted {converted} epic treasure "
-                                "chests to {to} legendary treasure chest{plural}. \n{author} "
+                                "chests to {to} legendary treasure chest{plur}. \n{author} "
                                 "now owns {normal} normal, {rare} rare, {epic} epic, "
                                 "{leg} legendary treasure chests and {set} set treasure chests."
                             ).format(


### PR DESCRIPTION
Fixes the following issue:

## Expected Behavior
Being able to convert epic chests to legendary.

## Actual Behavior
Discord message:
```
Error in command 'convert'. Check your console or logs for details.
```

Console output:
```
[2019-12-31 04:16:42] [ERROR] red: Exception in command 'convert'
Traceback (most recent call last):
  File "/home/kevin/.pyenv/versions/red-discord-bot-test/lib/python3.8/site-packages/discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/kevin/coding/discord-bots/draper/cogs/CogManager/cogs/adventure/adventure.py", line 1471, in convert
    _(
KeyError: 'plural'
```

## Steps to Reproduce the Problem
1. Setup character with 50 rebirths and 50 epic chests.
1. Do `[p]convert epic`.